### PR TITLE
Retry slicer settings fetch before reporting auth failures

### DIFF
--- a/custom_components/bambu_lab/pybambu/bambu_cloud.py
+++ b/custom_components/bambu_lab/pybambu/bambu_cloud.py
@@ -6,6 +6,7 @@ from enum import (
 import base64
 import json
 import requests
+import time
 
 cloudscraper_available = False
 try:
@@ -474,11 +475,20 @@ class BambuCloud:
 
     def get_slicer_settings(self) -> dict:
         LOGGER.debug("Getting slicer settings from Bambu Cloud")
-        try:
-            response = self._get(BambuUrl.SLICER_SETTINGS)
-        except:
-            return None
-        return response.json()
+        for attempt in range(3):
+            try:
+                response = self._get(BambuUrl.SLICER_SETTINGS)
+                return response.json()
+            except Exception as err:
+                LOGGER.debug(
+                    "Attempt %s to get slicer settings failed: %s",
+                    attempt + 1,
+                    err,
+                )
+                if attempt < 2:
+                    time.sleep(1)
+        LOGGER.warning("Failed to get slicer settings after 3 attempts")
+        return None
     
     # The task list is of the following form with a 'hits' array with typical 20 entries.
     #


### PR DESCRIPTION
## Summary
- Retry slicer settings download up to 3 times to handle transient Bambu Cloud errors

## Testing
- `python -m py_compile custom_components/bambu_lab/pybambu/bambu_cloud.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68b150038f1883319c2bed6512a7ef13