### PR TITLE
Delay authentication failure alert until after three retries

### DIFF
--- a/custom_components/bambu_lab/pybambu/models.py
+++ b/custom_components/bambu_lab/pybambu/models.py
@@ -3022,6 +3022,7 @@ class SlicerSettings:
     def __init__(self, client):
         self._client = client
         self.custom_filaments = {}
+        self._auth_failures = 0
 
     @property
     def filaments(self):
@@ -3054,8 +3055,12 @@ class SlicerSettings:
             LOGGER.debug("Loading slicer settings")
             slicer_settings = self._client.bambu_cloud.get_slicer_settings()
             if slicer_settings is None:
-                self._client.callback("event_printer_bambu_authentication_failed")
+                self._auth_failures += 1
+                if self._auth_failures >= 3:
+                    self._client.callback("event_printer_bambu_authentication_failed")
+                    self._auth_failures = 0
             else:
+                self._auth_failures = 0
                 self._load_custom_filaments(slicer_settings)
 
 class ExtruderTool:


### PR DESCRIPTION
## Summary
- Track consecutive authentication failures when loading slicer settings
- Only raise the `event_printer_bambu_authentication_failed` after three failed attempts

## Testing
- `PYTHONPATH=../.. python -m unittest test_models -v` *(fails: No module named 'paho')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Pillow>=10.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b157ee9a50833198f336c7837e8706